### PR TITLE
Update global.scss to remove navigation bar and category breadcrumb

### DIFF
--- a/common/global.scss
+++ b/common/global.scss
@@ -17,3 +17,7 @@ body {
 .d-header-icons .d-icon:hover {
   color: var(--primary);
 }
+
+ol.category-breadcrumb, ul#navigation-bar {
+  display: none;
+}

--- a/javascripts/discourse/connectors/before-topic-list/header-text-join-conversation-start-topic.hbs
+++ b/javascripts/discourse/connectors/before-topic-list/header-text-join-conversation-start-topic.hbs
@@ -1,0 +1,4 @@
+<div class="header-box">
+  <h1>Vendre sur Amazon & les autres Marketplaces</h1>
+  <p>Rejoignez les conversations ou démarrez un <a href="/new-topic">nouveau sujet</a></p>
+</div>


### PR DESCRIPTION
Edited `global.scss` to hide the following part:
![image](https://github.com/user-attachments/assets/95b098a7-50f2-4d9d-8033-40105e1861b1)
