### PR TITLE
Update topic-list.scss to place the category below the title and place the category name in the background color of the category.

### DIFF
--- a/common/topic-list.scss
+++ b/common/topic-list.scss
@@ -18,3 +18,24 @@
 .badge-wrapper.bullet .badge-category-bg {
   border-radius: 50%;
 }
+
+.topic-card .main-link {
+  display: grid;
+  grid-template-areas: "title title"
+  "tags tags"
+  "excerpt excerpt"
+  "op op"
+  "metadata metadata" !important;
+  grid-template-rows: auto auto 1fr auto auto;
+  flex-grow: 1;
+  padding: 1rem 1.5rem 1rem 0 !important;
+  box-sizing: border-box;
+  box-shadow: none !important;
+}
+
+.badge-category__wrapper {
+  background-color: var(--category-badge-color) !important;
+  color: var(--category-badge-text-color) !important;
+  border-radius: 1em;
+  padding: 0.5em;
+}

--- a/common/topic-list.scss
+++ b/common/topic-list.scss
@@ -39,3 +39,7 @@
   border-radius: 1em;
   padding: 0.5em;
 }
+
+.badge-category__wrapper .badge-category::before {
+  display: none;
+}


### PR DESCRIPTION
With multiple edits, the topic cards should look like this:
![image](https://github.com/user-attachments/assets/0db86f41-ee4e-4e53-ab53-23447c0d9bc5)

The category is now shown below the title, and the background color is the same as the category's color.