### PR TITLE
Put metadata next to topic title

### DIFF
--- a/common/topic-list.scss
+++ b/common/topic-list.scss
@@ -47,3 +47,7 @@
   flex-direction: row;
   margin-left: 0.5em;
 }
+
+.topic-card .main-link .topic-card__metadata .right-aligned {
+  margin-left: unset;
+}

--- a/common/topic-list.scss
+++ b/common/topic-list.scss
@@ -21,11 +21,10 @@
 
 .topic-card .main-link {
   display: grid;
-  grid-template-areas: "title title"
-  "tags tags"
+  grid-template-areas: "title metadata"
+  "tags metadata"
   "excerpt excerpt"
-  "op op"
-  "metadata metadata" !important;
+  "op op" !important;
   grid-template-rows: auto auto 1fr auto auto;
   flex-grow: 1;
   padding: 1rem 1.5rem 1rem 0 !important;
@@ -42,4 +41,9 @@
 
 .badge-category__wrapper .badge-category::before {
   display: none;
+}
+
+.topic-card .main-link .topic-card__metadata {
+  flex-direction: row;
+  margin-left: 0.5em;
 }


### PR DESCRIPTION
Changes the topic cards so that they now look like this:
![image](https://github.com/user-attachments/assets/475b2ed8-40ea-44bd-9adc-7bee6a216524)
