### PR TITLE
Put tags below title, put topic poster next to metadata

### DIFF
--- a/scss/common/topic-list.scss
+++ b/scss/common/topic-list.scss
@@ -20,16 +20,16 @@
 }
 
 .topic-card .main-link {
-  display: grid;
-  grid-template-areas: "title metadata"
-  "tags metadata"
-  "excerpt excerpt"
-  "op op" !important;
-  grid-template-rows: auto auto 1fr auto auto;
-  flex-grow: 1;
-  padding: 1rem 1.5rem 1rem 0 !important;
-  box-sizing: border-box;
-  box-shadow: none !important;
+    display: grid;
+    grid-template-areas: "title title"
+      "tags tags"
+      "excerpt excerpt"
+      "op metadata" !important;
+    grid-template-rows: auto auto 1fr auto auto;
+    flex-grow: 1;
+    padding: 1rem 1.5rem 1rem 0 !important;
+    box-sizing: border-box;
+    box-shadow: none !important;
 }
 
 .badge-category__wrapper {


### PR DESCRIPTION
With this PR, the topic card looks like this:
![image](https://github.com/user-attachments/assets/e2cdc74a-935d-424b-8ae8-f2bc062e7b9d)
The tags are placed below the title, with the topic poster next to the topic metadata.